### PR TITLE
fix: add Laravel 9 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "mbezhanov/faker-provider-collection": "^2.0",
-        "illuminate/support": "^5.1|^6.0|^7.0|^8.0"
+        "illuminate/support": "^5.1|^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
illuminate/support update is required to support a Laravel 9 project.